### PR TITLE
allow setting of context path and port

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ nexus_url: "{{ nexus_base_url }}/{{ nexus_tarfile }}"
 
 nexus_location: /opt/nexus
 nexus_home: "{{ nexus_location }}/{{ nexus_name }}"
+
+nexus_context_path: /
 ```
 
 Dependencies

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,3 +5,4 @@ nexus_workdir: /opt/nexus/sonatype-work/nexus3
 nexus_piddir: /var/run/nexus
 nexus_user: nexus
 nexus_group: nexus
+nexus_port: 8081

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -58,7 +58,7 @@
     dest: /etc/security/limits.d/nexus_limits.conf
     owner: root
     group: root
-  notify: restart Nexus
+  notify: restart nexus
 
 - name: verify presence of nexus
   stat:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -102,6 +102,27 @@
   tags:
     - nexus
 
+- name: create Nexus etc directory
+  file:
+    path: "{{ nexus_workdir }}/etc"
+    owner: "{{ nexus_user }}"
+    group: "{{ nexus_group }}"
+    mode: 0750
+    state: directory
+
+- name: update Nexus port
+  template:
+    src: nexus.properties
+    dest: "{{ nexus_workdir }}/etc/nexus.properties"
+    owner: "{{ nexus_user }}"
+    group: "{{ nexus_group }}"
+  notify:
+    - reload unit
+    - restart nexus
+  tags:
+    - nexus
+    - init
+
 - name: render Nexus systemd service file
   template:
     src: nexus.service

--- a/templates/nexus.properties
+++ b/templates/nexus.properties
@@ -1,0 +1,3 @@
+# Jetty section
+application-port={{ nexus_port }}
+nexus-context-path={{ nexus_context_path }}

--- a/templates/nexus.service
+++ b/templates/nexus.service
@@ -6,9 +6,9 @@ After=network.target
 Type=forking
 EnvironmentFile=/etc/profile.d/nexus.profile.sh
 #PIDFile={{ nexus_piddir }}/nexus.pid
-ExecStart={{ nexus_home }}/bin/nexus start
-ExecReload={{ nexus_home }}/bin/nexus restart
-ExecStop={{ nexus_home }}/bin/nexus stop
+ExecStart=/usr/local/nexus/bin/nexus start
+ExecReload=/usr/local/nexus/bin/nexus restart
+ExecStop=/usr/local/nexus/bin/nexus stop
 User={{ nexus_user }}
 Restart=on-abort
 

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -8,4 +8,4 @@ nexus_url: "{{ nexus_base_url }}/{{ nexus_tarfile }}"
 nexus_location: /opt/nexus
 nexus_home: "{{ nexus_location }}/{{ nexus_name }}"
 
-nexus_context_path: /nexus
+nexus_context_path: /

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -7,3 +7,5 @@ nexus_url: "{{ nexus_base_url }}/{{ nexus_tarfile }}"
 
 nexus_location: /opt/nexus
 nexus_home: "{{ nexus_location }}/{{ nexus_name }}"
+
+nexus_context_path: /nexus


### PR DESCRIPTION
* adds support for defining Nexus (Java) context path and port
  * defaults context path to `/` instead of `/nexus`
  * updates README with context path reference
* updates Unit file with symlinked location of `nexus`
* fixes notify for `copy limits file`
